### PR TITLE
Replaced GITHUB_TOKEN in workflow with own token

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,4 +61,4 @@ jobs:
       - name: Run publishing
         run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.GH_PUBLISH_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "variablechecker",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Simple helper to do variable checks and keep complexity low",
 	"main": "src/index.js",
 	"scripts": {


### PR DESCRIPTION
The built-in GITHUB_TOKEN seems to be broken and avoids publishing to gpr. I replaced it with an own access token from the secrets.